### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,9 @@ on:
     tags-ignore:
       - '**'
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/guillomep/go-unbound/security/code-scanning/1](https://github.com/guillomep/go-unbound/security/code-scanning/1)

**How to fix the problem:**  
Add a `permissions` block to the workflow YAML file at the appropriate level (the workflow level, before `jobs`, or at the job level inside the `build` job), setting it to the least privilege required for the workflow. The minimal starting point recommended by CodeQL is `contents: read`.

**Detailed description:**  
The best way to remedy the problem without changing existing functionality is to add a top-level `permissions:` block to `.github/workflows/ci.yaml`, immediately after the workflow name and triggers but before the `jobs:` key (e.g., between line 12 and 13). For most CI workflows (lint, test, build, uploading artifacts), `contents: read` is typically sufficient. If you discover that the workflow requires additional permissions later, you can expand the block as needed.

**What is needed:**  
- Addition of a top-level `permissions` block to `.github/workflows/ci.yaml`, after the trigger section and before `jobs:`.
- No additional imports, methods, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
